### PR TITLE
Include string.h and disable usbdevfs_disconnect

### DIFF
--- a/hubpower.c
+++ b/hubpower.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <strings.h>
+#include <string.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <sys/ioctl.h>
@@ -228,14 +229,15 @@ int main(int argc, char **argv)
     if (action == DO_POWER) {
         int i;
 
-        usb_ioctl.ifno = 0;
-        usb_ioctl.ioctl_code = USBDEVFS_DISCONNECT;
-        usb_ioctl.data = NULL;
-        rc = ioctl(fd, USBDEVFS_IOCTL, &usb_ioctl);
-        if (rc == -1 && errno != ENODATA) {
-            perror("Error in ioctl (USBDEVFS_DISCONNECT)");
-            return 1;
-        }
+				/* Disconnecting USBDEVFS turns off all devices on this hub */
+        /* usb_ioctl.ifno = 0; */
+        /* usb_ioctl.ioctl_code = USBDEVFS_DISCONNECT; */
+        /* usb_ioctl.data = NULL; */
+        /* rc = ioctl(fd, USBDEVFS_IOCTL, &usb_ioctl); */
+        /* if (rc == -1 && errno != ENODATA) { */
+        /*     perror("Error in ioctl (USBDEVFS_DISCONNECT)"); */
+        /*     return 1; */
+        /* } */
 
         for (i = 3; i < argc; i += 2) {
             portnum = atoi(argv[i]);
@@ -254,7 +256,6 @@ int main(int argc, char **argv)
                         argv[i+1]);
                 continue;
             }
-
             ctrl.bRequestType = USB_DIR_OUT | USB_TYPE_CLASS |
                     USB_RECIP_OTHER;
             ctrl.wValue = USB_PORT_FEAT_POWER;


### PR DESCRIPTION
Included string.h to compile and execute without errors.
Disabled usbdevfs because powering off a port caused power loss in the entire hub